### PR TITLE
[Distributed] distributedActor_destroy invoked instead, rather than before

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1309,7 +1309,7 @@ void swift::swift_distributedActor_destroy(DefaultActor *_actor) {
   //       something like: actor.transport.resignAddress(actor.address)
 
   // FIXME: if this is a proxy, we would destroy a bit differently I guess? less memory was allocated etc.
-  asImpl(_actor)->destroy();
+  asImpl(_actor)->destroy(); // today we just replicate what defaultActor_destroy does
 }
 
 void swift::swift_defaultActor_enqueue(Job *job, DefaultActor *_actor) {


### PR DESCRIPTION
For now let's just call the distributed deinit; we'll see if we just call the normal one or if the distributed will call through etc...