### PR TITLE
[distributed] typechecking for _remote_ functions existing, add tests for remote funcs

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3110,6 +3110,11 @@ public:
                                           OptionSet<LookupDirectFlags> flags =
                                           OptionSet<LookupDirectFlags>());
 
+  /// Find the '_remote_<...>' counterpart function to a 'distributed func'.
+  ///
+  /// If the passed in function is not distributed this function returns null.
+  AbstractFunctionDecl* lookupDirectRemoteFunc(AbstractFunctionDecl *func);
+
   /// Collect the set of protocols to which this type should implicitly
   /// conform, such as AnyObject (for classes).
   void getImplicitProtocols(SmallVectorImpl<ProtocolDecl *> &protocols);

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4358,6 +4358,20 @@ ERROR(distributed_actor_func_param_not_codable,none,
 ERROR(distributed_actor_func_result_not_codable,none,
       "distributed function result type %0 does not conform to 'Codable'",
       (Type))
+ERROR(distributed_actor_func_missing_remote_func,none,
+      "distributed function is missing its remote static func implementation (%0). "
+      "You may want to use a distributed actor SwiftPM plugin to generate those, "
+      "or implement it manually.",
+      (Identifier))
+ERROR(distributed_actor_remote_func_is_not_static,none,
+      "remote function %0 must be static.",
+      (DeclName))
+ERROR(distributed_actor_remote_func_is_not_async_throws,none,
+      "remote function %0 must be 'async throws'.",
+      (DeclName))
+ERROR(distributed_actor_remote_func_must_not_be_distributed,none,
+      "remote function %0 must be 'async throws'.",
+      (DeclName))
 NOTE(actor_mutable_state,none,
      "mutation of this %0 is only permitted within the actor",
      (DescriptiveDeclKind))

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1400,6 +1400,31 @@ NominalTypeDecl::lookupDirect(DeclName name,
                            DirectLookupRequest({this, name, flags}), {});
 }
 
+AbstractFunctionDecl*
+NominalTypeDecl::lookupDirectRemoteFunc(AbstractFunctionDecl *func) {
+  auto &C = func->getASTContext();
+  auto *selfTyDecl = func->getParent()->getSelfNominalTypeDecl();
+
+  // _remote functions only exist as counterparts to a distributed function.
+  if (!func->isDistributed())
+    return nullptr;
+
+  auto localFuncName = func->getBaseIdentifier().str().str();
+  auto remoteFuncId = C.getIdentifier("_remote_" + localFuncName);
+
+  auto remoteFuncDecls = selfTyDecl->lookupDirect(DeclName(remoteFuncId));
+  if (remoteFuncDecls.empty())
+    return nullptr;
+
+  if (auto remoteDecl = dyn_cast<AbstractFunctionDecl>(remoteFuncDecls.front())) {
+    // TODO: implement more checks here, it has to be the exact right signature.
+    return remoteDecl;
+  }
+
+  remoteFuncDecls.front()->dump();
+  assert(false && "Found some decl, but it is not a func");
+}
+
 TinyPtrVector<ValueDecl *>
 DirectLookupRequest::evaluate(Evaluator &evaluator,
                               DirectLookupDescriptor desc) const {

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -2033,12 +2033,10 @@ void SILGenFunction::emitDistributedThunk(SILDeclRef thunk) {
 
 
   // if __isRemoteActor(self) {
-  //   return try await Self._distributed_X(...)
+  //   return try await Self._remote_X(...)
   // }
   {
     B.emitBlock(isRemoteBB);
-
-    auto remoteFnId = ctx.getIdentifier("_remote_" + fd->getBaseIdentifier().str().str());
 
     auto *selfTyDecl = FunctionDC->getParent()->getSelfNominalTypeDecl();
     // FIXME: should this be an llvm_unreachable instead?
@@ -2047,13 +2045,8 @@ void SILGenFunction::emitDistributedThunk(SILDeclRef thunk) {
     auto selfMetatype = getLoweredType(selfTyDecl->getInterfaceType());
     SILValue metatypeValue = B.createMetatype(loc, selfMetatype);
 
-    auto remoteFnDecls = selfTyDecl->lookupDirect(DeclName(remoteFnId));
-
-    // TODO: handle properly
-    assert(!remoteFnDecls.empty());
-
-    auto *remoteFnDecl = dyn_cast<FuncDecl>(remoteFnDecls.front());
-    assert(remoteFnDecl);
+    auto remoteFnDecl = selfTyDecl->lookupDirectRemoteFunc(fd);
+    assert(remoteFnDecl && "Could not find _remote_<dist_func_name> function");
     auto remoteFnRef = SILDeclRef(remoteFnDecl);
 
     SILGenFunctionBuilder builder(SGM);

--- a/stdlib/public/Concurrency/DistributedActor.swift
+++ b/stdlib/public/Concurrency/DistributedActor.swift
@@ -144,12 +144,36 @@ public struct ActorAddress: Codable, ConcurrentValue, Equatable {
   public var uid: UInt64 // TODO: should we remove this
 
   public init(parse: String) {
-    self.protocol = "xxx"
+    self.protocol = "sact"
     self.host = "xxx"
     self.port = 7337
     self.nodeID = 11
-    self.path = "/example"
+    self.path = "example"
     self.uid = 123123
+  }
+}
+
+// TODO: naive impl, bring in a real one
+extension ActorAddress: CustomStringConvertible {
+  public var description: String {
+    var result = `protocol`
+    result += "://"
+    if let host = host {
+      result += host
+    }
+    if let port = port {
+      result += ":\(port)"
+    }
+//    if let nodeID = nodeID {
+//      result += "@\(nodeID)"
+//    }
+    if let path = path {
+      result += "/\(path)"
+    }
+    if uid > 0 {
+      result += "#\(uid)"
+    }
+    return result
   }
 }
 

--- a/test/Concurrency/Runtime/distributed_actor_isRemote.swift
+++ b/test/Concurrency/Runtime/distributed_actor_isRemote.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -7,6 +7,15 @@ import Dispatch
 import _Concurrency
 
 distributed actor SomeSpecificDistributedActor {
+  distributed func hello() async throws -> String {
+    "local impl"
+  }
+}
+
+extension SomeSpecificDistributedActor {
+  static func _remote_hello(actor: SomeSpecificDistributedActor) async throws -> String {
+    return "remote impl (address: \(actor.actorAddress))"
+  }
 }
 
 // ==== Fake Transport ---------------------------------------------------------

--- a/test/Concurrency/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Concurrency/Runtime/distributed_actor_remote_functions.swift
@@ -1,0 +1,149 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+import Dispatch
+import _Concurrency
+
+struct Boom: Error {}
+
+distributed actor SomeSpecificDistributedActor {
+  let state: String = "hi there"
+
+  distributed func helloAsyncThrows() async throws -> String {
+    "local(\(#function))"
+  }
+
+//  distributed func helloAsync() async -> String {
+//    "local(\(#function))"
+//  }
+//
+//  distributed func helloThrows() throws -> String {
+//    "local(\(#function))"
+//  }
+//
+//  distributed func hello() -> String {
+//    "local(\(#function))"
+//  }
+//
+//  // === errors
+//
+//  distributed func helloThrowsImplBoom() throws -> String {
+//    throw Boom()
+//  }
+//
+//  distributed func helloThrowsTransportBoom() throws -> String {
+//    "local(\(#function))"
+//  }
+
+}
+
+extension SomeSpecificDistributedActor {
+
+  static func _remote_helloAsyncThrows(actor: SomeSpecificDistributedActor) async throws -> String {
+    return "remote(\(#function)) (address: \(actor.actorAddress))"
+  }
+
+//  static func _remote_helloAsync(actor: SomeSpecificDistributedActor) async throws -> String {
+//    return "remote(\(#function)) (address: \(actor.actorAddress))"
+//  }
+//
+//  static func _remote_helloThrows(actor: SomeSpecificDistributedActor) async throws -> String {
+//    return "remote(\(#function)) (address: \(actor.actorAddress))"
+//  }
+//
+//  static func _remote_hello(actor: SomeSpecificDistributedActor) async throws -> String {
+//    return "remote(\(#function)) (address: \(actor.actorAddress))"
+//  }
+//
+//  // === errors
+//
+//  static func _remote_helloThrowsImplBoom(actor: SomeSpecificDistributedActor) async throws -> String {
+//    return "remote(\(#function)) (address: \(actor.actorAddress))"
+//  }
+//
+//  static func _remote_helloThrowsTransportBoom(actor: SomeSpecificDistributedActor) async throws -> String {
+//    throw Boom()
+//  }
+}
+
+// ==== Fake Transport ---------------------------------------------------------
+
+struct FakeTransport: ActorTransport {
+  func resolve<Act>(address: ActorAddress, as actorType: Act.Type)
+    throws -> ActorResolved<Act> where Act: DistributedActor {
+    return .makeProxy
+  }
+
+  func assignAddress<Act>(
+    _ actorType: Act.Type
+//    ,
+//    onActorCreated: (Act) -> ()
+  ) -> ActorAddress where Act : DistributedActor {
+    ActorAddress(parse: "")
+  }
+}
+
+// ==== Execute ----------------------------------------------------------------
+let address = ActorAddress(parse: "")
+let transport = FakeTransport()
+
+func test_remote_invoke() async {
+  func check(actor: SomeSpecificDistributedActor) async {
+    let personality = __isRemoteActor(actor) ? "remote" : "local"
+
+    let h1 = try! await actor.helloAsyncThrows()
+    print("\(personality) - helloAsyncThrows: \(h1)")
+
+//    let h2 = try! await remote.helloAsync()
+//    print("\(personality) - helloAsync: \(h2)")
+//
+//    let h3 = try! await remote.helloThrows()
+//    print("\(personality) - helloThrows: \(h3)")
+//
+//    let h4 = try! await remote.hello()
+//    print("\(personality) - hello: \(h4)")
+//
+//    // error throws
+//    do {
+//      try await remote.helloThrowsTransportBoom()
+//      preconditionFailure("Should have thrown")
+//    } catch {
+//      print("\(personality) - helloThrowsTransportBoom: \(error)")
+//    }
+//
+//    do {
+//      try await remote.helloThrowsImplBoom()
+//      preconditionFailure("Should have thrown")
+//    } catch {
+//      print("\(personality) - helloThrowsImplBoom: \(error)")
+//    }
+  }
+
+  let remote = try! SomeSpecificDistributedActor(resolve: address, using: transport)
+  assert(__isRemoteActor(remote) == true, "should be remote")
+
+  let local = SomeSpecificDistributedActor(transport: transport)
+  assert(__isRemoteActor(local) == false, "should be local")
+
+  print("local isRemote: \(__isRemoteActor(local))")
+  // CHECK: local isRemote: false
+  await check(actor: local)
+  // CHECK: local - helloAsyncThrows: local(helloAsyncThrows())
+
+
+  print("remote isRemote: \(__isRemoteActor(remote))")
+  // CHECK: remote isRemote: true
+  await check(actor: remote)
+  // CHECK: remote - helloAsyncThrows: remote(_remote_helloAsyncThrows(actor:))
+
+  print(local)
+  print(remote)
+}
+
+@main struct Main {
+  static func main() async {
+    await test_remote_invoke()
+  }
+}


### PR DESCRIPTION
Adds:

- typechecking for existence of `_remote` functions
  - warming up to synthesizing some default thing for them actually I guess...
- tests for distributed funcs actually calling _remote funcs when the actor is remote


FYI @drexin